### PR TITLE
Add alt text to portfolio images

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         fjs.parentNode.insertBefore(js, fjs);
       }(document, 'script', 'facebook-jssdk'));
     </script>
-    <img alt='' class='bg' src='images/bg.jpg'>
+    <img alt='Background image' class='bg' src='images/bg.jpg'>
     <div class='wrap'>
       <nav class='menu'>
         <ul>
@@ -107,7 +107,7 @@
           </ul>
         </section>
         <section id='who'>
-          <img alt='' src='images/me.jpg'>
+          <img alt='Roman profile photo' src='images/me.jpg'>
           <h1>
             <span class='first'>My name is Roman</span>
             <span class='second alignleft'>
@@ -123,7 +123,7 @@
         <section id='how'>
           <ul>
             <li>
-              <img alt='' src='images/yep.jpg'>
+              <img alt='Screenshot of the yep! promo site' src='images/yep.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -146,7 +146,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/medoroby.jpg'>
+              <img alt='Screenshot of the Medoroby site' src='images/medoroby.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -159,7 +159,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/classicshome.jpg'>
+              <img alt='Screenshot of the Classics at Home site' src='images/classicshome.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -172,7 +172,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/ammonitum.jpg'>
+              <img alt='Screenshot of the Ammonitum Interiors site' src='images/ammonitum.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -191,7 +191,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/bbc.jpg'>
+              <img alt='Screenshot of the BBC Baubetreuung site' src='images/bbc.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -206,7 +206,7 @@
               </span>
             </li>            
             <li>
-              <img alt='' src='images/bookforum.jpg'>
+              <img alt='Screenshot of the Publishers' Forum site' src='images/bookforum.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -221,7 +221,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/kemeodesign.jpg'>
+              <img alt='Screenshot of the Kemeo Design site' src='images/kemeodesign.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -236,7 +236,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/labslots.jpg'>
+              <img alt='Screenshot of the Labslots site' src='images/labslots.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -251,7 +251,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/lonckoho.jpg'>
+              <img alt='Screenshot of the Lontsky Prison Museum site' src='images/lonckoho.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -264,7 +264,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/runstyle.jpg'>
+              <img alt='Screenshot of the Runstyle site' src='images/runstyle.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -279,7 +279,7 @@
               </span>
             </li>            
             <li>
-              <img alt='' src='images/rottmann.jpg'>
+              <img alt='Screenshot of the Carl Rottmann site' src='images/rottmann.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -294,7 +294,7 @@
               </span>
             </li>
             <li>
-              <img alt='' src='images/arma.jpg'>
+              <img alt='Screenshot of the Arma Forge site' src='images/arma.jpg'>
               <span class='close'></span>
               <span class='desc'>
                 <h2>
@@ -342,7 +342,7 @@
     </script>
     <noscript>
       <div>
-        <img alt='' src='https://mc.yandex.ru/watch/33839804' style='position:absolute; left:-9999px;'>
+        <img alt='Yandex analytics tracking pixel' src='https://mc.yandex.ru/watch/33839804' style='position:absolute; left:-9999px;'>
       </div>
     </noscript>
   </body>


### PR DESCRIPTION
## Summary
- add meaningful alt attributes for images on the main page

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d337ec48322b42b8448e4885943